### PR TITLE
Update the linter.py to accommodate for change in the next release of salt-lint

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -3,8 +3,8 @@ from SublimeLinter import lint
 
 class SaltLint(lint.Linter):
     name = 'salt-lint'
-    cmd = ('salt-lint', '--nocolor', '${args}', '${file}')
-    regex = (r'(?P<code>\d+) (?P<message>.+)\s+'
+    cmd = ('salt-lint', '--nocolor', '${args}')
+    regex = (r'\[(?P<code>\d+)\] (?P<message>.+)\s+'
              r'.+:(?P<line>\d+)\s+'
              r'(?P<near>.+)')
     multiline = True


### PR DESCRIPTION
The next release of salt-lint will:
- accept input over stdin
- fix an issue that changes the output of the not-coloured option

These changes will accommodate for this update.
