### PR TITLE
Read file as argument instead of creating a temporary file read from stdin

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,7 @@ from SublimeLinter import lint
 
 class SaltLint(lint.Linter):
     name = 'salt-lint'
-    cmd = ('salt-lint', '--nocolor', '${args}')
+    cmd = ('salt-lint', '--nocolor', '${args}', '${file}')
     regex = (r'\[(?P<code>\d+)\] (?P<message>.+)\s+'
              r'.+:(?P<line>\d+)\s+'
              r'(?P<near>.+)')


### PR DESCRIPTION
`salt-lint` currently creates a temporary file when reading a file from stdin. This seems unnecessary for this plugin, since we already have a file to read.